### PR TITLE
Unnecessary global variables.

### DIFF
--- a/lib/range.js
+++ b/lib/range.js
@@ -112,8 +112,8 @@ function increaseRangeBitDepth(ranges, radiusBitDepth, bitDepth) {
 
     var bitDiff = bitDepth - radiusBitDepth;
 
-    for (i = 0; i < ranges.length; i++) {
-        range = ranges[i];
+    for (var i = 0; i < ranges.length; i++) {
+        var range = ranges[i];
         range[0] = leftShift(range[0], bitDiff);
         range[1] = leftShift(range[1], bitDiff);
     }

--- a/lib/range.js
+++ b/lib/range.js
@@ -111,9 +111,10 @@ function rangesFromBoxSet(neighbors) {
 function increaseRangeBitDepth(ranges, radiusBitDepth, bitDepth) {
 
     var bitDiff = bitDepth - radiusBitDepth;
-
+    var range;
+    
     for (var i = 0; i < ranges.length; i++) {
-        var range = ranges[i];
+        range = ranges[i];
         range[0] = leftShift(range[0], bitDiff);
         range[1] = leftShift(range[1], bitDiff);
     }


### PR DESCRIPTION
module was failing when run with '--use-strict' flag.